### PR TITLE
Update Docker entrypoint to use a custom script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,6 @@ RUN apt-get update \
 
 WORKDIR /opt/sipp
 
-ENTRYPOINT /usr/bin/sipp
+ADD entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -e
+RUN_ID=$(date +%s%N)
+exec /usr/bin/sipp -cid_str "$RUN_ID"-%u-%p@%s "$@"


### PR DESCRIPTION
Replaced the direct `sipp` invocation with a custom `entrypoint.sh` script. The script generates a unique `RUN_ID` for each execution and passes it as part of the `sipp` command arguments to ensure uniqueness. This change improves runtime flexibility and debugging capabilities.